### PR TITLE
Add config option to change vertical position of the second hotbar

### DIFF
--- a/src/main/java/com/sidezbros/double_hotbar/DHModConfig.java
+++ b/src/main/java/com/sidezbros/double_hotbar/DHModConfig.java
@@ -21,4 +21,7 @@ public class DHModConfig implements ConfigData {
 	@ConfigEntry.BoundedDiscrete(min = 1, max = 3)
 	public int inventoryRow = 3;
 
+	@ConfigEntry.BoundedDiscrete(min = 0, max = 100)
+	public int shift = 24;
+
 }

--- a/src/main/java/com/sidezbros/double_hotbar/DHModConfig.java
+++ b/src/main/java/com/sidezbros/double_hotbar/DHModConfig.java
@@ -22,6 +22,6 @@ public class DHModConfig implements ConfigData {
 	public int inventoryRow = 3;
 
 	@ConfigEntry.BoundedDiscrete(min = 0, max = 100)
-	public int shift = 24;
+	public int shift = 21;
 
 }

--- a/src/main/java/com/sidezbros/double_hotbar/mixin/InGameHudMixin.java
+++ b/src/main/java/com/sidezbros/double_hotbar/mixin/InGameHudMixin.java
@@ -17,8 +17,6 @@ import net.minecraft.item.ItemStack;
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin extends DrawableHelper{
 
-	
-	private final int shift = 21;
 	private boolean onScreen = false;
 	@Shadow private int scaledHeight;
 	@Shadow private int scaledWidth;
@@ -28,7 +26,7 @@ public abstract class InGameHudMixin extends DrawableHelper{
 	@Inject(method = "renderHotbar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;drawTexture(Lnet/minecraft/client/util/math/MatrixStack;IIIIII)V", ordinal = 0))
 	private void renderHotbarFrame(float tickDelta, MatrixStack matrices, CallbackInfo info) {
 		if(DHModConfig.INSTANCE.displayDoubleHotbar) {
-			this.drawTexture(matrices, this.scaledWidth / 2 - 91, this.scaledHeight - 22 - this.shift, 0, 0, 182, 22);
+			this.drawTexture(matrices, this.scaledWidth / 2 - 91, this.scaledHeight - 22 - DHModConfig.INSTANCE.shift, 0, 0, 182, 22);
 			this.onScreen = true;
 		}
 		
@@ -41,7 +39,7 @@ public abstract class InGameHudMixin extends DrawableHelper{
 			for (int n2 = 0; n2 < 9; ++n2) {
 		            int o = this.scaledWidth / 2 - 90 + n2 * 20 + 2;
 		            int p = this.scaledHeight - 16 - 3;
-		            this.renderHotbarItem(o, p-this.shift, tickDelta, getCameraPlayer(), getCameraPlayer().getInventory().main.get(n2+DHModConfig.INSTANCE.inventoryRow*9), m++);
+		            this.renderHotbarItem(o, p-DHModConfig.INSTANCE.shift, tickDelta, getCameraPlayer(), getCameraPlayer().getInventory().main.get(n2+DHModConfig.INSTANCE.inventoryRow*9), m++);
 		    }
 		}
 	}
@@ -49,7 +47,7 @@ public abstract class InGameHudMixin extends DrawableHelper{
 	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;hasStatusBars()Z"))
 	public void shiftStatusBars(MatrixStack matrices, float tickDelta, CallbackInfo info) {
 		if(this.onScreen) {
-			matrices.translate(0, -this.shift, 0);
+			matrices.translate(0, -DHModConfig.INSTANCE.shift, 0);
 		}
 	}
 	
@@ -57,7 +55,7 @@ public abstract class InGameHudMixin extends DrawableHelper{
 	@Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;getSleepTimer()I", ordinal = 0))
 	public void returnStatusBars(MatrixStack matrices, float tickDelta, CallbackInfo info) {
 		if(this.onScreen) {
-			matrices.translate(0, this.shift, 0);
+			matrices.translate(0, DHModConfig.INSTANCE.shift, 0);
 		}
 		this.onScreen = false;
 	}

--- a/src/main/resources/assets/double_hotbar/lang/en_us.json
+++ b/src/main/resources/assets/double_hotbar/lang/en_us.json
@@ -3,5 +3,6 @@
   "key.double_hotbar.swap": "Swap Hotbars",
   "text.autoconfig.double_hotbar.option.displayDoubleHotbar": "Show Second Hotbar",
   "text.autoconfig.double_hotbar.option.inventoryRow": "Selected Inventory Row",
+  "text.autoconfig.double_hotbar.option.shift": "Vertical Position",
   "text.autoconfig.double_hotbar.title":"Double Hotbar Config"
 }


### PR DESCRIPTION
This change is designed for use principally with mods like [Raised](https://www.curseforge.com/minecraft/mc-mods/raised), which adjust the hotbar position up a few pixels so the selector can be fully visible on-screen. Without this change, using this mod in conjunction with Raised results in a displeasing overlap between the two hotbars.

This change was accomplished by removing the shift constant in `InGameHudMixin`, and replacing all references to it with a config variable. This config variable is an integer slider bounded from 0 to 100 (the upper limit is arbitrary and could be changed, named 'Vertical Position' in the lang file.